### PR TITLE
Reformat license to be the allowed classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     classifiers=[
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: BSD 3-Clause License",
+        "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3",
         "Development Status :: 4 - Beta",
     ],


### PR DESCRIPTION
Run into error while uploading with twine: 
```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/                                                                                                                                                                                                                                           
         'License :: OSI Approved :: BSD 3-Clause License' is not a valid classifier. See https://packaging.python.org/specifications/core-metadata for more information.  
```
It seems that the allowed classifiers are here: https://pypi.org/classifiers/