### PR TITLE
Add ability to filter gnomAD using ClinVar data

### DIFF
--- a/gnomad_toolbox/filtering/clinvar.py
+++ b/gnomad_toolbox/filtering/clinvar.py
@@ -1,0 +1,115 @@
+"""Functions to filter gnomAD variants and join with ClinVar data."""
+
+from typing import List, Optional, Union
+
+import hail as hl
+from gnomad.utils.filtering import filter_by_intervals
+from gnomad.utils.reference_genome import get_reference_genome
+
+from gnomad_toolbox.filtering.variant import filter_by_gene_symbol
+from gnomad_toolbox.load_data import _get_dataset
+from gnomad_toolbox.load_reference_data import (
+    _import_clinvar_vcf,
+    _load_clinvar_resource,
+)
+
+
+def filter_variants_by_clinvar(
+    max_af_threshold: float = 0.01,
+    min_af_threshold: Optional[float] = None,
+    download_clinvar: bool = False,
+    genes: Optional[Union[str, List[str]]] = None,
+    intervals: Optional[Union[str, List[str], hl.Interval, List[hl.Interval]]] = None,
+    contig: Optional[str] = None,
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+    clinvar_significances: List[str] = [
+        "pathogenic",
+        "likely_pathogenic",
+        "uncertain_significance",
+    ],
+    clinvar_download_path: Optional[str] = None,
+    clinvar_output_path: Optional[str] = None,
+    **kwargs,
+) -> hl.Table:
+    """
+    Filter gnomAD variants by gene(s) or interval(s), join with ClinVar data, and filter by AF threshold.
+
+    .. note::
+
+        One of `genes`, `interval`, or all of `contig`, `start`, and `end` must be
+        provided. The function will filter variants based on the provided criteria,
+        then join with ClinVar data and filter to retain only variants with the
+        specified ClinVar clinical significances.
+
+    :param max_af_threshold: Maximum allele frequency threshold. Default is 0.01.
+    :param min_af_threshold: Minimum allele frequency threshold. If provided, variants
+        with allele frequencies below this threshold will be excluded.
+    :param download_clinvar: If True, download latest ClinVar VCF. If False, use gnomAD ClinVar resource from gnomad_methods.
+        Default is False.
+    :param genes: Single gene name or list of gene names to filter by. If provided,
+        `intervals`, `contig`, `start`, and `end` are ignored.
+    :param intervals: Single interval string (e.g., "chr1:1000-2000"), list of interval
+        strings, Hail interval object, or list of Hail interval objects.
+        If provided, `genes`, `contig`, `start`, and `end` are ignored.
+    :param contig: Chromosome/contig name. Required if using `start` and `end`.
+    :param start: Start position. Required if using `contig` and `end`.
+    :param end: End position. Required if using `contig` and `start`.
+    :param clinvar_significances: List of ClinVar clinical significances to retain.
+        Default is ["Pathogenic", "Likely_pathogenic", "Uncertain_significance"].
+    :param clinvar_download_path: Path to download ClinVar VCF. Required if `download_clinvar` is True.
+        Default is None.
+    :param clinvar_output_path: Path to store ClinVar Hail Table. Required if `download_clinvar` is True.
+        Default is None.
+    :param kwargs: Additional arguments to pass to `_get_dataset`.
+    :return: Hail Table containing filtered variants with ClinVar annotations.
+    """
+    # Load gnomAD data.
+    ht = _get_dataset(dataset="variant", **kwargs)
+    build = get_reference_genome(ht.locus).name
+
+    # Apply gene/interval filtering.
+    if genes is not None:
+        if isinstance(genes, str):
+            genes = [genes]
+        ht = filter_by_gene_symbol(genes[0], **kwargs)
+        for gene in genes[1:]:
+            ht = ht.union(filter_by_gene_symbol(gene, **kwargs))
+    elif intervals is not None:
+        ht = filter_by_intervals(ht, intervals)
+    elif all(x is not None for x in [contig, start, end]):
+        interval = f"{contig}:{start}-{end}"
+        ht = filter_by_intervals(ht, interval)
+    else:
+        raise ValueError(
+            "Must provide either genes, intervals, or contig/start/end parameters."
+        )
+
+    # Filter by AF thresholds.
+    af_expr = ht.freq[0].AF if "freq" in ht.row else ht.af[0].AF
+    if min_af_threshold is not None:
+        ht = ht.filter(af_expr > min_af_threshold)
+    ht = ht.filter(af_expr <= max_af_threshold)
+
+    if download_clinvar:
+        # Import ClinVar data.
+        clinvar_ht = _import_clinvar_vcf(
+            build=build,
+            clinvar_download_path=clinvar_download_path,
+            output_path=clinvar_output_path,
+        )
+    else:
+        # Load ClinVar data from gnomad_methods.
+        clinvar_ht = _load_clinvar_resource(build=build)
+        clinvar_ht = clinvar_ht.transmute(**clinvar_ht.info)
+
+    # Join ClinVar data with gnomAD data.
+    ht = ht.annotate(
+        clinvar=clinvar_ht[ht.key].select("CLNSIG", "CLNREVSTAT", "CLNDN", "CLNDISDB")
+    )
+
+    # Filter to specified ClinVar significances.
+    clinvar_filter = hl.literal(clinvar_significances).contains(ht.clinvar.CLNSIG)
+    ht = ht.filter(clinvar_filter)
+
+    return ht

--- a/gnomad_toolbox/load_data.py
+++ b/gnomad_toolbox/load_data.py
@@ -112,6 +112,13 @@ SUPPORTED_REFERENCE_DATA = {
             "v39": {"reference_genome": "GRCh38"},
         },
     },
+    "clinvar": {
+        "resource": "clinvar",
+        "versions": {
+            "grch37": {"reference_genome": "GRCh37"},
+            "grch38": {"reference_genome": "GRCh38"},
+        },
+    },
 }
 
 

--- a/gnomad_toolbox/load_reference_data.py
+++ b/gnomad_toolbox/load_reference_data.py
@@ -1,4 +1,10 @@
-"""Functions to import non-gnomAD reference data."""
+"""
+Functions to import non-gnomAD reference data.
+
+This module provides functions to load and import various reference datasets.
+
+Currently, this module includes functions to load ClinVar data from gnomad_methods or by downloading from NCBI.
+"""
 
 import hail as hl
 import requests
@@ -14,6 +20,28 @@ CLINVAR_FTP_URL = {
 """
 Path to the latest weekly ClinVar VCF release for GRCh37 and GRCh38.
 """
+
+
+def _load_clinvar_resource(build: str) -> hl.Table:
+    """
+    Load ClinVar resource from gnomad_methods based on reference genome build.
+
+    :param build: Reference genome build ('GRCh37' or 'GRCh38').
+    :return: Hail Table with ClinVar data containing fields like `CLNSIG`, `CLNREVSTAT`,
+        `CLNDN`, `CLNDISDB`, etc.
+    """
+    if build == "GRCh37":
+        import gnomad.resources.grch37 as grch37_res
+
+        return grch37_res.reference_data.clinvar.ht()
+    elif build == "GRCh38":
+        import gnomad.resources.grch38 as grch38_res
+
+        return grch38_res.reference_data.clinvar.ht()
+    else:
+        raise ValueError(
+            f"Unsupported reference genome build: {build}. Must be 'GRCh37' or 'GRCh38'."
+        )
 
 
 def _import_clinvar_vcf(

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,45 @@
+# Tests
+
+This directory contains tests for the gnomad-toolbox package.
+
+## Running Tests
+
+To run all tests:
+
+```bash
+python -m pytest
+```
+
+To run specific test files:
+
+```bash
+python -m pytest tests/test_clinvar_loading.py
+python -m pytest tests/test_clinvar_filtering.py
+```
+
+To run tests with verbose output:
+
+```bash
+python -m pytest -v
+```
+
+To run tests and show coverage:
+
+```bash
+python -m pytest --cov=gnomad_toolbox
+```
+
+## Test Structure
+
+- `conftest.py`: Pytest configuration and fixtures
+- `test_clinvar_loading.py`: Tests for ClinVar resource loading functionality
+- `test_clinvar_filtering.py`: Tests for ClinVar filtering functionality
+- `test_placeholder.py`: Placeholder test to ensure test suite works
+
+## Test Conventions
+
+- Tests are organized in classes that group related functionality
+- Each test method has a descriptive name and docstring
+- Tests use pytest fixtures and parametrization where appropriate
+- Tests include both positive and negative test cases
+- Tests check for expected exceptions and error conditions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Pytest configuration for gnomad-toolbox tests."""
+
+import pytest
+import hail as hl
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_hail():
+    """
+    Set up Hail before running tests.
+
+    This fixture will ensure that the Hail context is initialized only once per test
+    session and will be stopped after all tests are completed.
+    """
+    if not hl.utils.java.Env.is_fully_initialized():
+        hl.init(log="/dev/null")
+
+    yield
+    hl.stop()

--- a/tests/test_clinvar_filtering.py
+++ b/tests/test_clinvar_filtering.py
@@ -1,0 +1,114 @@
+"""Tests for ClinVar filtering functionality."""
+
+import pytest
+import hail as hl
+
+from gnomad_toolbox.filtering.clinvar import filter_variants_by_clinvar
+
+
+class TestClinVarFiltering:
+    """Test class for ClinVar filtering functionality."""
+
+    def test_filter_variants_by_clinvar_basic_functionality(self) -> None:
+        """Test basic functionality of filter_variants_by_clinvar."""
+        # Test with a small interval to avoid loading too much data.
+        result = filter_variants_by_clinvar(
+            # Part of BRCA1 gene interval.
+            intervals="chr17:43044295-43044305",
+            max_af_threshold=0.01,
+            download_clinvar=False,
+        )
+
+        # Check that we get a Hail Table.
+        assert isinstance(result, hl.Table)
+
+        # Check that the result has ClinVar annotations.
+        if result.count() > 0:
+            assert "clinvar" in result.row, "Expected 'clinvar' annotation in result"
+
+            # Check that clinvar annotation has expected fields.
+            clinvar_fields = ["CLNSIG", "CLNREVSTAT", "CLNDN", "CLNDISDB"]
+            for field in clinvar_fields:
+                assert field in result.clinvar, f"Expected field {field} in clinvar annotation"
+
+    def test_filter_variants_by_clinvar_with_genes(self) -> None:
+        """Test filter_variants_by_clinvar with gene filtering."""
+        # Test with a single gene.
+        result = filter_variants_by_clinvar(
+            genes="BRCA1",
+            max_af_threshold=0.01,
+            download_clinvar=False,
+        )
+
+        # Check that we get a Hail Table.
+        assert isinstance(result, hl.Table)
+
+        # Check that the result has ClinVar annotations.
+        if result.count() > 0:
+            assert "clinvar" in result.row, "Expected 'clinvar' annotation in result"
+
+    def test_filter_variants_by_clinvar_with_multiple_genes(self) -> None:
+        """Test filter_variants_by_clinvar with multiple genes."""
+        # Test with multiple genes.
+        result = filter_variants_by_clinvar(
+            genes=["BRCA1", "BRCA2"],
+            max_af_threshold=0.01,
+            download_clinvar=False,
+        )
+
+        # Check that we get a Hail Table.
+        assert isinstance(result, hl.Table)
+
+        # Check that the result has ClinVar annotations.
+        if result.count() > 0:
+            assert "clinvar" in result.row, "Expected 'clinvar' annotation in result"
+
+    def test_filter_variants_by_clinvar_af_thresholds(self) -> None:
+        """Test filter_variants_by_clinvar with two AF thresholds."""
+        # Test with both min and max AF thresholds.
+        result = filter_variants_by_clinvar(
+            intervals="chr17:43044295-43044305",
+            max_af_threshold=0.001,
+            min_af_threshold=0.0001,
+            download_clinvar=False,
+        )
+
+        # Check that we get a Hail Table
+        assert isinstance(result, hl.Table)
+
+    def test_filter_variants_by_clinvar_custom_significances(self) -> None:
+        """Test filter_variants_by_clinvar with custom ClinVar significances."""
+        # Test with custom significances.
+        result = filter_variants_by_clinvar(
+            intervals="chr17:43044295-43044305",
+            clinvar_significances=["pathogenic", "likely_pathogenic"],
+            download_clinvar=False,
+        )
+
+        # Check that we get a Hail Table
+        assert isinstance(result, hl.Table)
+
+    def test_filter_variants_by_clinvar_missing_parameters(self) -> None:
+        """Test that filter_variants_by_clinvar raises error with missing parameters."""
+        with pytest.raises(ValueError, match="Must provide either genes, intervals, or contig/start/end parameters"):
+            filter_variants_by_clinvar(
+                max_af_threshold=0.01,
+                download_clinvar=False,
+            )
+
+    def test_filter_variants_by_clinvar_with_contig_start_end(self) -> None:
+        """Test filter_variants_by_clinvar with contig/start/end parameters."""
+        result = filter_variants_by_clinvar(
+            contig="chr17",
+            start=43044295,
+            end=43044305,
+            max_af_threshold=0.01,
+            download_clinvar=False,
+        )
+
+        # Check that we get a Hail Table
+        assert isinstance(result, hl.Table)
+
+        # Check that the result has ClinVar annotations
+        if result.count() > 0:
+            assert "clinvar" in result.row, "Expected 'clinvar' annotation in result"

--- a/tests/test_clinvar_loading.py
+++ b/tests/test_clinvar_loading.py
@@ -1,0 +1,35 @@
+"""Tests for ClinVar loading functionality."""
+
+import pytest
+import hail as hl
+
+from gnomad_toolbox.load_reference_data import _load_clinvar_resource
+
+
+class TestClinVarLoading:
+    """Test class for ClinVar loading functionality."""
+
+    def test_load_clinvar_resource_invalid_build(self) -> None:
+        """Test that invalid reference genome build raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported reference genome build"):
+            _load_clinvar_resource("invalid_build")
+
+
+    @pytest.mark.parametrize("build", ["GRCh37", "GRCh38"])
+    def test_clinvar_resource_basic_properties(self, build: str) -> None:
+        """Test basic properties of ClinVar resources for both builds."""
+        clinvar_ht = _load_clinvar_resource(build)
+
+        # Basic type checks
+        assert isinstance(clinvar_ht, hl.Table)
+        assert clinvar_ht.count() > 0
+
+        # Check that the table has the required key fields
+        assert "locus" in clinvar_ht.key
+        assert "alleles" in clinvar_ht.key
+
+        # Check that the table has the required row fields
+        clinvar_ht = clinvar_ht.transmute(**clinvar_ht.info)
+        required_fields = ["CLNSIG", "CLNREVSTAT", "CLNDN", "CLNDISDB"]
+        for field in required_fields:
+            assert field in clinvar_ht.row, f"Missing required field: {field}"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.

To make sure that this change is included in release notes, please:
- Use a descriptive title for the pull request.
- Apply one of the "Changelog" labels (if applicable).

-->
PR adds support for gnomAD public ClinVar resources, new script to join gnomAD+ClinVar data and filter on frequency and ClinVar clinical significance, and tests (generated by Cursor)